### PR TITLE
Make .get always return a value, even if it is expired

### DIFF
--- a/src/lru.js
+++ b/src/lru.js
@@ -73,10 +73,11 @@ class LRU {
 		if (this.has(key)) {
 			const item = this.items[key];
 
+			result = item.value;
+
 			if (this.ttl > 0 && item.expiry <= new Date().getTime()) {
 				this.delete(key);
 			} else {
-				result = item.value;
 				this.set(key, result, true);
 			}
 		}


### PR DESCRIPTION
This fixes an issue where you could

```js
if (cache.has(key)) {
	const value = cache.get(key)
	// assume that value is a legit value
}
```

and have issues because cache.has will return true if the item is in the map, but then the call to .get would delete the item if it was expired and return undefined.