### PR TITLE
Remove ttl as an option

### DIFF
--- a/src/lru.js
+++ b/src/lru.js
@@ -68,20 +68,14 @@ class LRU {
 	}
 
 	get (key) {
-		let result;
-
 		if (this.has(key)) {
-			const item = this.items[key];
+			const result = this.items[key];
+			this.set(key, result, true);
 
-			if (this.ttl > 0 && item.expiry <= new Date().getTime()) {
-				this.delete(key);
-			} else {
-				result = item.value;
-				this.set(key, result, true);
-			}
+			return result;
 		}
 
-		return result;
+		return undefined;
 	}
 
 	keys () {

--- a/src/lru.js
+++ b/src/lru.js
@@ -1,11 +1,10 @@
 class LRU {
-	constructor (max = 0, ttl = 0) {
+	constructor (max = 0) {
 		this.first = null;
 		this.items = Object.create(null);
 		this.last = null;
 		this.max = max;
 		this.size = 0;
-		this.ttl = ttl;
 	}
 
 	has (key) {
@@ -116,7 +115,6 @@ class LRU {
 			}
 
 			item = this.items[key] = {
-				expiry: this.ttl > 0 ? new Date().getTime() + this.ttl : this.ttl,
 				key: key,
 				prev: this.last,
 				next: null,
@@ -136,14 +134,10 @@ class LRU {
 	}
 }
 
-export function lru (max = 1000, ttl = 0) {
+export function lru (max = 1000) {
 	if (isNaN(max) || max < 0) {
 		throw new TypeError("Invalid max value");
 	}
 
-	if (isNaN(ttl) || ttl < 0) {
-		throw new TypeError("Invalid ttl value");
-	}
-
-	return new LRU(max, ttl);
+	return new LRU(max);
 }


### PR DESCRIPTION
An alternative to 495e2b7481d4a3255f92931484318656dc157a9d

This fixes an issue where you could

```js
if (cache.has(key)) {
	const value = cache.get(key)
	// assume that value is a legit value
}
```

and have the call to cache.get() return undefined even though you just checked that it was there by calling cache.has().

It seems counterintuitive (and counter to the docs) that a call to get() would ever remove an item from the cache.